### PR TITLE
Update subxt to read constants from metadata at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,7 +1396,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "futures",
- "once_cell",
  "parity-scale-codec",
  "subxt",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,8 +2298,8 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subxt"
-version = "0.18.1"
-source = "git+https://github.com/paritytech/subxt.git?branch=at-block-stats#16d4306dfa7725d11c1c7f0539b4b3e3f0d99443"
+version = "0.19.0"
+source = "git+https://github.com/paritytech/subxt.git?branch=aj/runtime-constants#3cc2c420093da85dcfa56e4bea0098b0deb2816a"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -2322,8 +2322,8 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.18.1"
-source = "git+https://github.com/paritytech/subxt.git?branch=at-block-stats#16d4306dfa7725d11c1c7f0539b4b3e3f0d99443"
+version = "0.19.0"
+source = "git+https://github.com/paritytech/subxt.git?branch=aj/runtime-constants#3cc2c420093da85dcfa56e4bea0098b0deb2816a"
 dependencies = [
  "async-trait",
  "darling",
@@ -2340,8 +2340,8 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.18.1"
-source = "git+https://github.com/paritytech/subxt.git?branch=at-block-stats#16d4306dfa7725d11c1c7f0539b4b3e3f0d99443"
+version = "0.19.0"
+source = "git+https://github.com/paritytech/subxt.git?branch=aj/runtime-constants#3cc2c420093da85dcfa56e4bea0098b0deb2816a"
 dependencies = [
  "async-trait",
  "darling",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,7 +2299,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "subxt"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/subxt.git?branch=aj/runtime-constants#3cc2c420093da85dcfa56e4bea0098b0deb2816a"
+source = "git+https://github.com/paritytech/subxt.git?branch=master#cc0b1ec84acae528a5172ce87398bfef48e9cf2d"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -2323,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "subxt-codegen"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/subxt.git?branch=aj/runtime-constants#3cc2c420093da85dcfa56e4bea0098b0deb2816a"
+source = "git+https://github.com/paritytech/subxt.git?branch=master#cc0b1ec84acae528a5172ce87398bfef48e9cf2d"
 dependencies = [
  "async-trait",
  "darling",
@@ -2341,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "subxt-macro"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/subxt.git?branch=aj/runtime-constants#3cc2c420093da85dcfa56e4bea0098b0deb2816a"
+source = "git+https://github.com/paritytech/subxt.git?branch=master#cc0b1ec84acae528a5172ce87398bfef48e9cf2d"
 dependencies = [
  "async-trait",
  "darling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 clap = { version = "3", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3"  }
 futures = "0.3"
-subxt = { git = "https://github.com/paritytech/subxt.git", branch = "at-block-stats" }
+subxt = { git = "https://github.com/paritytech/subxt.git", branch = "aj/runtime-constants" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 once_cell = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,3 @@ codec = { package = "parity-scale-codec", version = "3"  }
 futures = "0.3"
 subxt = { git = "https://github.com/paritytech/subxt.git", branch = "master" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-once_cell = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 clap = { version = "3", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3"  }
 futures = "0.3"
-subxt = { git = "https://github.com/paritytech/subxt.git", branch = "aj/runtime-constants" }
+subxt = { git = "https://github.com/paritytech/subxt.git", branch = "master" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 once_cell = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use futures::{TryStream, TryStreamExt};
 use std::{boxed::Box, fmt, sync::Arc};
 use subxt::{
     rpc::RpcError, sp_runtime::traits::Header, ClientBuilder, DefaultConfig,
-    SubstrateExtrinsicParams
+    SubstrateExtrinsicParams,
 };
 
 /// 50% of what is stored in configuration::activeConfig::maxPovSize at the relay chain.
@@ -11,7 +11,8 @@ const POV_MAX: u64 = 5_242_880 / 2;
 #[subxt::subxt(runtime_metadata_path = "metadata/substrate.scale")]
 pub mod substrate {}
 
-type SubstrateRuntime = substrate::RuntimeApi<DefaultConfig, SubstrateExtrinsicParams<DefaultConfig>>;
+type SubstrateRuntime =
+    substrate::RuntimeApi<DefaultConfig, SubstrateExtrinsicParams<DefaultConfig>>;
 
 #[derive(Debug)]
 pub struct BlockStats {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 use futures::{TryStream, TryStreamExt};
 use std::{boxed::Box, fmt, sync::Arc};
 use subxt::{
-    rpc::RpcError, sp_runtime::traits::Header, ClientBuilder, DefaultConfig, DefaultExtra,
+    rpc::RpcError, sp_runtime::traits::Header, ClientBuilder, DefaultConfig,
+    SubstrateExtrinsicParams
 };
 
 /// 50% of what is stored in configuration::activeConfig::maxPovSize at the relay chain.
@@ -10,7 +11,7 @@ const POV_MAX: u64 = 5_242_880 / 2;
 #[subxt::subxt(runtime_metadata_path = "metadata/substrate.scale")]
 pub mod substrate {}
 
-type SubstrateRuntime = substrate::RuntimeApi<DefaultConfig, DefaultExtra<DefaultConfig>>;
+type SubstrateRuntime = substrate::RuntimeApi<DefaultConfig, SubstrateExtrinsicParams<DefaultConfig>>;
 
 #[derive(Debug)]
 pub struct BlockStats {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ impl fmt::Display for BlockStats {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{:04}: PoV Size={:04}KiB({:03}%) Weight={:07}µs({:03}%) Witness={:04}KiB Block={:04}KiB NumExtrinsics={:04}",
+            "{:04}: PoV Size={:04}KiB({:03}%) Weight={:07}ms({:03}%) Witness={:04}KiB Block={:04}KiB NumExtrinsics={:04}",
             self.number,
             self.pov_len / 1024,
             self.pov_len * 100 / self.max_pov,


### PR DESCRIPTION
Currently the constant `let max_weight = api.constants().system().block_weights().unwrap();` is defined statically from the metadata used in the codegen. So it can obviously differ from the actual value defined in the target node (and they do differ between e.g. `substrate-contracts-node` and `canvas-parachain`. See https://github.com/paritytech/subxt/issues/493.

This PR updates `subxt` to `master` which now includes https://github.com/paritytech/subxt/pull/494 which uses the metadata fetched from the node at runtime for the constant values.